### PR TITLE
Refactor useKitchenGetOrders function

### DIFF
--- a/src/app/hooks/getOrdersInKitchen.js
+++ b/src/app/hooks/getOrdersInKitchen.js
@@ -61,7 +61,13 @@ export default function useKitchenGetOrders (bar = false) {
         return
       }
 
-      play()
+      if (bar === true && newOrder.pending_list[0].type === 1) {
+        play()
+      }
+
+      if (bar === false && newOrder.pending_list[0].type !== 1) {
+        play()
+      }
 
       setOrders(prev => {
         const copyOrder = [...prev]


### PR DESCRIPTION
## Se han añadido dos condiciones
para verificar que si estamos dentro de el usuario de barra y la orden contiene elementos de bebidas, se reproduzca el sonido, tambien si el usuario es de cocina y las ordenes contienen platillos, se reproduzca, de esta forma evitando la reproduccion en barra cuando no existen bebidas en la orden o cuando no se esta en el usuario de barra

![image](https://github.com/Foco-Grafico/los-arbolitos/assets/78590985/a25bad97-ec56-4369-ae0a-3419280fb06f)
